### PR TITLE
update settings to older version of js and css assets

### DIFF
--- a/src/material_widgets/settings.py
+++ b/src/material_widgets/settings.py
@@ -20,11 +20,11 @@ Path joins can be used as long as they result in a valid URL string.
 from django.conf import settings
 
 MATERIAL_CSS = getattr(settings, 'MATERIAL_CSS',
-                       ("https://unpkg.com/material-components-web@latest"
+                       ("https://unpkg.com/material-components-web@0.25.0"
                         + "/dist/material-components-web.min.css")
                       )
 
 MATERIAL_JS = getattr(settings, 'MATERIAL_JS',
-                      ("https://unpkg.com/material-components-web@latest"
+                      ("https://unpkg.com/material-components-web@0.25.0"
                        + "/dist/material-components-web.min.js")
                      )


### PR DESCRIPTION
Currently the project pulls in the latest css and js assets from the material components project. The html structure is out of date, so the widgets do not work as expected.

It seems like it would be better to pin the js and css assets to the most recent known working version.